### PR TITLE
Improve test helper and reporting reliability

### DIFF
--- a/tests/testthat/test_r_functionality.R
+++ b/tests/testthat/test_r_functionality.R
@@ -73,7 +73,10 @@ posthoc_stats <- list(
 
 basic_plot <- ggplot2::ggplot(sample_df, ggplot2::aes(x = ConditionID, y = value)) + ggplot2::geom_point()
 
-with_mock <- testthat::with_mocked_bindings
+# Helper wrapper to avoid relying on pkgload/devtools metadata when mocking
+with_mock <- function(..., .env = parent.frame()) {
+  testthat::with_mocked_bindings(..., .package = "base", .env = .env)
+}
 
 
 #### basic utilities ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a local with_mock helper in tests to avoid pkgload dependency
- ensure ANOVA assumption checks return invisibly with informative message
- add fallbacks for effect size calculations and xtable output in reporting helpers

## Testing
- Not run (Rscript not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921cfb7c4e08332a9b76f0f167091ce)